### PR TITLE
Add application context to payment data type

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -57,6 +57,7 @@ module PayPal::SDK
           object_of :id, String
           object_of :intent, String
           object_of :payer, Payer
+          object_of :application_context, ApplicationContext
           object_of :payee, Payee
           object_of :cart, String
           array_of  :transactions, Transaction
@@ -297,6 +298,30 @@ module PayPal::SDK
           object_of :related_funding_option, FundingOption
           object_of :payer_info, PayerInfo
           object_of :billing, Billing
+        end
+      end
+
+      class ApplicationContext < Base
+        def self.load_members
+          object_of :brand_name, String
+          object_of :locale, String
+          object_of :landing_page, String
+          object_of :shipping_preference, String
+          object_of :user_action, String
+          object_of :preferred_payment_source, ApplicationContextPaymentSource
+        end
+      end
+
+      class ApplicationContextPaymentSource < Base
+        def self.load_members
+          object_of :token, PaymentSourceToken
+        end
+      end
+
+      class PaymentSourceToken < Base
+        def self.load_members
+          object_of :id, String
+          object_of :type, String
         end
       end
 

--- a/spec/core/api/payment_data_type_spec.rb
+++ b/spec/core/api/payment_data_type_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Payment do
+  subject { described_class.new(payment_attributes) }
+
+  describe '.new' do
+    let(:payment_attributes) do
+      {
+        intent: 'sale',
+        payer: { payment_method: 'paypal' },
+        application_context: {
+          brand_name: 'My Brand',
+          locale: 'en_US',
+          landing_page: 'Billing',
+          shipping_preference: 'NO_SHIPPING',
+          user_action: 'commit',
+          preferred_payment_source: {
+            token: {
+              id: 'payment-token-id-generated-by-paypal',
+              type: 'BILLING_AGREEMENT'
+            }
+          }
+        }
+      }
+    end
+
+    describe '"application_context" key' do
+      let(:application_context) { subject.application_context }
+
+      it 'should convert the "application_context" value in an instance of ApplicationContext DataType' do
+        expect(application_context).to be_a ApplicationContext
+      end
+
+      it 'should set "brand_name" value correctly' do
+        expect(application_context.brand_name).to eq 'My Brand'
+      end
+
+      it 'should set "locale" value correctly' do
+        expect(application_context.locale).to eq 'en_US'
+      end
+
+      it 'should set "landing_page" value correctly' do
+        expect(application_context.landing_page).to eq 'Billing'
+      end
+
+      it 'should set "shipping_preference" value correctly' do
+        expect(application_context.shipping_preference).to eq 'NO_SHIPPING'
+      end
+
+      it 'should set "user_action" value correctly' do
+        expect(application_context.user_action).to eq 'commit'
+      end
+
+      describe '"preferred_payment_source" key' do
+        let(:payment_source) { application_context.preferred_payment_source }
+
+        it 'should convert "preferred_payment_source" in an instance of ApplicationContextPaymentSource datatype' do
+          expect(payment_source).to be_a ApplicationContextPaymentSource
+        end
+
+        describe '"preferred_payment_source.token" key' do
+          let(:token) { payment_source.token }
+
+          it 'should convert "token" in an instance of PaymentSourceToken datatype' do
+            expect(token).to be_a PaymentSourceToken
+          end
+
+          it 'should set "id" value correctly' do
+            expect(token.id).to eq 'payment-token-id-generated-by-paypal'
+          end
+
+          it 'should set "type" value correctly' do
+            expect(token.type).to eq 'BILLING_AGREEMENT'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

- [x] Create new `ApplicationContext` data type and add to `Payment` data type.
- [x] Added specs for `ApplicationContext` data type